### PR TITLE
Use timestamp from last git commit if available

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -8,9 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TERM: xterm
+      TZ: Europe/Berlin
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
+        with:
+          fetch-depth: 0
 
       - name: Install and Build 🔧
         run: |

--- a/build.sh
+++ b/build.sh
@@ -113,13 +113,23 @@ status "Building recipe pages..."
 for FILE in _recipes/*.md; do
     CATEGORY_FAUX_URLENCODED="$(cat "_temp/$(basename "$FILE" .md).category.txt" | cut -d" " -f2- | awk -f "_templates/technical/faux_urlencode.awk")"
 
+    # when running under GitHub Actions, use the last commit date
+    # for the updatedtime. You'll probably also want to set the
+    # TZ environment variable to your local timezone in the
+    # workflow.
+    if [[ "$GITHUB_ACTIONS" = true ]]; then
+        UPDATED_AT="$(git log -1 --date=short-local --pretty='format:%cd' "$FILE")"
+    else
+        UPDATED_AT="$(date -r "$FILE" "+%Y-%m-%d")"
+    fi
+
     # set basename to enable linking to github in the footer, and set
     # category_faux_urlencoded in order to link to that in the header
     x pandoc "$FILE" \
         --metadata-file config.yaml \
         --metadata basename="$(basename "$FILE" .md)" \
         --metadata category_faux_urlencoded="$CATEGORY_FAUX_URLENCODED" \
-        --metadata updatedtime="$(date -r "$FILE" "+%Y-%m-%d")" \
+        --metadata updatedtime="$UPDATED_AT" \
         --template _templates/recipe.template.html \
         -o "_site/$(basename "$FILE" .md).html"
 done


### PR DESCRIPTION
If you use GitHub Actions to build the site, it will always use the current date for the "updated at" value of each page, because that's the date of the checkout. Instead use the date of the last commit for each file instead, if it is available.